### PR TITLE
PR to implement issue #2.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -11,6 +11,8 @@ var openController = (function openControllerIIFE() {
 
     if (config !== undefined && typeof config.perLang === 'object' && Object.keys(config.perLang).length > 0) {
 
+      var success = false;
+      var defaultOptions;
       for (var i = 0, len = config.perLang.opnOptions.length; i < len; i++) {
 
         var opnOptionObj = config.perLang.opnOptions[i];
@@ -18,10 +20,16 @@ var openController = (function openControllerIIFE() {
         if (activeTextEditor.document.languageId === opnOptionObj.forLang) {
 
           fileService.openFileLocation(fileService.getFileLocation(activeTextEditor, config, opnOptionObj), opnOptionObj);
+          success = true;
           break;
 
+        } else if (opnOptionObj.forLang === 'default') {
+          defaultOptions = opnOptionObj;
         }
 
+      }
+      if (!success) {
+        fileService.openFileLocation(fileService.getFileLocation(activeTextEditor, config, defaultOptions), defaultOptions);
       }
 
     } else {

--- a/libs/fileService.js
+++ b/libs/fileService.js
@@ -7,9 +7,9 @@ var url = require('url');
 
 var fileService = function fileServiceAnonFn() {
 
-  var fileLocationFsPath = function fileLocationFsPathAnonFn(activeTextEditor) {
+  var fileLocationFsPath = function fileLocationFsPathAnonFn(document) {
 
-    return activeTextEditor.document.uri.fsPath.toString();
+    return document.uri.fsPath.toString();
 
   };
 
@@ -19,24 +19,24 @@ var fileService = function fileServiceAnonFn() {
 
   };
 
-  var fileLocationUri = function fileLocationUriAnonFn(activeTextEditor) {
+  var fileLocationUri = function fileLocationUriAnonFn(document) {
 
     // Bug workaround: https://github.com/Microsoft/vscode/issues/2990
-    if (activeTextEditor.document.uri.scheme.toString() === 'file') {
+    if (document.uri.scheme.toString() === 'file') {
 
-      return 'file://' + fixedEncodeURI(activeTextEditor.document.uri.path.toString());
+      return 'file://' + fixedEncodeURI(document.uri.path.toString());
 
     } else {
 
-      return activeTextEditor.document.uri.toString();
+      return document.uri.toString();
 
     }
 
   };
 
-  var fileLocationUrl = function fileLocationUrlAnonFn(activeTextEditor, config) {
+  var fileLocationUrl = function fileLocationUrlAnonFn(document, config) {
 
-    var relativePath = path.relative(vscode.workspace.rootPath, activeTextEditor.document.fileName);
+    var relativePath = path.relative(vscode.workspace.rootPath, document.fileName);
     var relativeUrl = fixedEncodeURI(relativePath.replace(/\\/g, '/'));
 
     var urlObj = {
@@ -50,23 +50,23 @@ var fileService = function fileServiceAnonFn() {
 
   };
 
-  var getFileLocation = function getFileLocationAnonFn(activeTextEditor, config, opnOptionObj) {
+  var getFileLocation = function getFileLocationAnonFn(document, config, opnOptionObj) {
 
     if (opnOptionObj === undefined) {
 
-      return fileLocationUri(activeTextEditor);
+      return fileLocationUri(document);
 
     } else if (opnOptionObj.isUseWebServer) {
 
-      return fileLocationUrl(activeTextEditor, config);
+      return fileLocationUrl(document, config);
 
     } else if (opnOptionObj.isUseFsPath) {
 
-      return fileLocationFsPath(activeTextEditor);
+      return fileLocationFsPath(document);
 
     } else {
 
-      return fileLocationUri(activeTextEditor);
+      return fileLocationUri(document);
     }
 
   };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/lfurzewaddock/vscode-opn"
   },
   "engines": {
-    "vscode": "^0.10.6"
+    "vscode": "^1.6.0"
   },
   "categories": [
     "Other"
@@ -43,6 +43,20 @@
   ],
   "main": "./extension",
   "contributes": {
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "extension.opn",
+          "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "extension.opn",
+          "group": "navigation"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "extension.opn",
@@ -93,7 +107,7 @@
     "decache": "^3.0.3",
     "jscs": "^2.10.1",
     "jshint": "^2.9.1",
-    "vscode": "^0.11.0"
+    "vscode": "^1.0.5"
   },
   "license": "See LICENSE.txt"
 }


### PR DESCRIPTION
This commit adds a context menu entry to the explorer and an associated
command to open the file (which was clicked on) in an external program.

The external program can be configured using the extension's
configuration under the key `externalEditor`. The key can accept full
paths to the tools or just the name of the program if it is present in
PATH. Arguments to be passed to the program can also be specified in the
accompanying configuration under the key `externalEditorArgs`.

Example configuration:

```
"vscode-opn.externalEditor": "emacs",
"vscode-opn.externalEditorArgs": [
    "+10",
    "-nbc"
]
```
